### PR TITLE
Mise à jour du fichier de config

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -3,7 +3,7 @@ max-line-length = 99
 exclude = **/migrations/*,venv
 
 [tool.coverage.run]
-omit = ["/usr"]
+omit = ["/usr", "*/six.py"]
 
 [tool:pytest]
 DJANGO_SETTINGS_MODULE = oc_lettings_site.settings


### PR DESCRIPTION
Ajout : --cov-fail-under=80

[tool.coverage.run]
omit = ["/usr", "*/six.py"]